### PR TITLE
Capability to set manual parameters

### DIFF
--- a/spec/Task/Plugin/Console/CommandRunnerSpec.php
+++ b/spec/Task/Plugin/Console/CommandRunnerSpec.php
@@ -66,6 +66,17 @@ class CommandRunnerSpec extends ObjectBehavior
         $this->run($output);
     }
 
+    function it_should_run_a_command_with_manually_set_parameters(Application $app, Command $command, InputDefinition $definition, OutputInterface $output)
+    {
+        $this->setup($app, $command, $definition);
+
+        $this->setParameter('--foo', 'bar');
+        $input = new ArrayInput(['command' => 'test', '--foo' => 'bar']);
+
+        $app->run($input, $output)->shouldBeCalled();
+        $this->run($output);
+    }
+
     function it_should_throw_on_unknown_argument(Application $app, Command $command, InputDefinition $definition)
     {
         $this->setup($app, $command, $definition);

--- a/src/CommandRunner.php
+++ b/src/CommandRunner.php
@@ -92,4 +92,11 @@ class CommandRunner implements ReadableInterface
     {
         return $this->parameters;
     }
+
+    public function setParameter($param, $value)
+    {
+        $this->parameters[$param] = $value;
+        return $this;
+    }
+
 }


### PR DESCRIPTION
Added setParameter to supplement the magic set method which doesn't allow you to set an argument that is the same name as an option (e.g. option --version and a version argument as is the case with using doctrine/migrations).
